### PR TITLE
Add CONTRIBUTING and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change. 
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a 
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment 
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you 
+   do not have permission to do that, you may request the second reviewer to merge it for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,67 @@ email, or any other method with the owners of this repository before making a ch
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
+## Contributing to Question
+
+Thank you for your interest in contributing to our open-source project! Before you start, please take a moment to read and follow our forking and branch naming conventions to ensure smooth collaboration.
+### Forking Conventions
+
+1. Fork Repository Name:
+When you fork the repository, please maintain the original repository's name:
+   - Original Repository: `ComputerSocietyVITC/Question`  
+   - Forked Repository: `your-username/Question`
+
+2. Forking Workflow:
+   - Fork the original repository to your GitHub account.
+   - Clone your forked repository to your local development environment.
+   - Configure the upstream repository to keep your fork up to date:  
+      ```bash
+      git remote add upstream https://github.com/ComputerSocietyVITC/Question.git
+      ```
+3. Pulling from Upstream:
+
+    - Regularly update your forked repository with changes from the upstream repository:
+      ```bash
+        git fetch upstream
+        git checkout main
+        git merge upstream/main
+        git push origin main
+      ```
+### Branch Naming Conventions
+
+#### Branch Types:
+- Use the following branch types:
+   - `feature/`: For new features or enhancements.
+   - `bugfix/`: For bug fixes.
+   - `hotfix/`: For critical fixes that need immediate attention.
+   - `chore/`: For routine tasks, maintenance, or tooling changes.
+   - `doc/`: For documentation updates.
+   - `refactor/`: For code refactoring.
+   - `test/`: For adding or modifying tests.
+
+- Branch Name Format:
+   - Follow this format for branch names:
+      - Use lowercase letters and hyphens.
+      - Start with the branch type followed by a brief, descriptive name.
+      - Include the issue number if applicable.  
+            Examples:
+                feature/add-new-feature
+                bugfix/fix-issue-123
+                doc/update-readme
+
+- Example Workflow:
+   - Create a new branch for your work based on the main branch:
+      ```bash
+         git checkout main
+         git pull upstream main
+         git checkout -b feature/my-new-feature
+      ```
+### Pull Request Naming:
+- When creating a pull request, use a clear and descriptive title.
+- Reference any related issues or feature requests in the pull request description using keywords like "Fixes #123" or "Closes #456."
+
+By adhering to these forking and branch naming conventions, you help maintain a well-organized and collaborative development environment for our open-source project. We appreciate your contributions!
+
 ## Pull Request Process
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a 


### PR DESCRIPTION
This DPR addresses #4 
Added in the basic templates for contribution and code of conduct, as seen on any normal open source repository.
@AbhijithGanesh if you have any organization specific contribution rules or code of conduct to be added, please let me know.